### PR TITLE
Add litcoffee to Markdown Extensions

### DIFF
--- a/OmniMarkupLib/Renderers/MarkdownRenderer.py
+++ b/OmniMarkupLib/Renderers/MarkdownRenderer.py
@@ -5,7 +5,7 @@ import markdown
 
 @renderer
 class MarkdownRenderer(MarkupRenderer):
-    FILENAME_PATTERN_RE = re.compile(r'\.(md|mkdn?|mdwn|mdown|markdown)$')
+    FILENAME_PATTERN_RE = re.compile(r'\.(md|mkdn?|mdwn|mdown|markdown|litcoffee)$')
 
     def load_settings(self, renderer_options, global_setting):
         super(MarkdownRenderer, self).load_settings(renderer_options, global_setting)


### PR DESCRIPTION
A simple change that recognizes [literate CoffeeScript](http://coffeescript.org/#literate) as a valid Markdown format.
