### PR TITLE
Fix TypeError exception when launching web browser under XFCE 4

### DIFF
--- a/OmniMarkupLib/desktop/__init__.py
+++ b/OmniMarkupLib/desktop/__init__.py
@@ -137,7 +137,7 @@ def _is_xfce():
     # XFCE detection involves testing the output of a program.
 
     try:
-        return _readfrom(_get_x11_vars() + "xprop -root _DT_SAVE_MODE", shell=1).strip().endswith(' = "xfce4"')
+        return _readfrom(_get_x11_vars() + "xprop -root _DT_SAVE_MODE", shell=1).strip().decode("utf-8").endswith(' = "xfce4"')
     except OSError:
         return 0
 


### PR DESCRIPTION
The _readfrom function returns bytes, but .endswith() expects a string.

---

This commit fixes this exception I get under Xfce 4.8:

``` python

OmniMarkupPreviewer: [INFO] Launching web browser for http://localhost:51004/view/28
OmniMarkupPreviewer: [ERROR] Error while launching default web browser
  Traceback (most recent call last):
    File "/home/u/.config/sublime-text-3/Packages/OmniMarkupPreviewer/OmniMarkupPreviewer.py", line 93, in launching_web_browser_for_url
    desktop.open(url)
    File "/home/u/.config/sublime-text-3/Packages/OmniMarkupPreviewer/OmniMarkupLib/desktop/__init__.py", line 261, in open
    desktop_in_use = use_desktop(desktop)
    File "/home/u/.config/sublime-text-3/Packages/OmniMarkupPreviewer/OmniMarkupLib/desktop/__init__.py", line 198, in use_desktop
    detected = get_desktop()
    File "/home/u/.config/sublime-text-3/Packages/OmniMarkupPreviewer/OmniMarkupLib/desktop/__init__.py", line 177, in get_desktop
    elif _is_xfce():
    File "/home/u/.config/sublime-text-3/Packages/OmniMarkupPreviewer/OmniMarkupLib/desktop/__init__.py", line 140, in _is_xfce
    return _readfrom(_get_x11_vars() + "xprop -root _DT_SAVE_MODE", shell=1).strip().endswith(' = "xfce4"')
  TypeError: endswith first arg must be bytes or a tuple of bytes, not str

```
