### PR TITLE
fix: no need to encode arguments in python 3.x

### DIFF
--- a/OmniMarkupPreviewer.py
+++ b/OmniMarkupPreviewer.py
@@ -72,7 +72,7 @@ def launching_web_browser_for_url(url, success_msg_default=None, success_msg_use
             browser_command = [os.path.expandvars(arg).format(url=url)
                                for arg in setting.browser_command]
 
-            if os.name == 'nt':
+            if os.name == 'nt' and PY3K != True:
                 # unicode arguments broken under windows
                 encoding = locale.getpreferredencoding()
                 browser_command = [arg.encode(encoding) for arg in browser_command]


### PR DESCRIPTION
  It seems there is no need to encode arguments in python 3.x, it reports errors on Windows while I set "browser_command": ["C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe","{url}"],:
```
OmniMarkupPreviewer: [ERROR] Error while launching user defined web browser
  Traceback (most recent call last):
    File "C:\Users\Ansiz\AppData\Roaming\Sublime Text 3\Packages\OmniMarkupPreviewer\OmniMarkupPreviewer.py", line 81, in launching_web_browser_for_url
    subprocess.Popen(browser_command)
    File "./python3.3/subprocess.py", line 819, in __init__
    File "./python3.3/subprocess.py", line 1063, in _execute_child
    File "./python3.3/subprocess.py", line 632, in list2cmdline
  TypeError: Type str doesn't support the buffer API
```